### PR TITLE
fix: Escaped single quotation marks

### DIFF
--- a/src/BpmnModeler.ts
+++ b/src/BpmnModeler.ts
@@ -175,6 +175,9 @@ export class BpmnModeler implements vscode.CustomTextEditorProvider {
             extensionUri, 'dist', 'client', 'assets', 'bpmn-font', 'css', 'bpmn.css'
         ));
 
+        const bpmnXML = JSON.stringify(initialContent).replace(/'/g, "\\'");
+        const data = JSON.stringify(files);
+
         const nonce = this.getNonce();
 
         return `
@@ -219,9 +222,9 @@ export class BpmnModeler implements vscode.CustomTextEditorProvider {
                 const vscode = acquireVsCodeApi();
                 const state = vscode.getState();
                 if (!state) {
-                    vscode.setState({
-                      text: '${JSON.stringify(initialContent)}',
-                      files: '${JSON.stringify(files)}'    // serialize files-Array
+                    vscode.setState({ 
+                      text: '${bpmnXML}',
+                      files: '${data}'   // serialize files-Array
                     });
                 }
               </script>


### PR DESCRIPTION
A user told me he had problems opening some of his rather simple `.bpmn` models in our VS Code Modeler Plugin. 
I did some research and found out that it was due to the expression used in the outgoing sequence flow of the exclusive gateway. 

`<bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${processInstance.friendlyShoulder.type == 'complaint'}</bpmn:conditionExpression>`

The issue was that the single quotation mark (') was not properly escaped, hence it resulted into an error and the user cannot see any graphical representation of the diagram.  

Changes:  
* Added regex for escaping the single quotation mark in `BpmnModeler.ts`

This has been fixed in collaboration with @peterhnm :) 
Ty!  